### PR TITLE
fixes user credentials on mysql import

### DIFF
--- a/5.7/files/import.sh
+++ b/5.7/files/import.sh
@@ -5,7 +5,7 @@ files=`find /db -name '*.sql'`
 # if sql dump(s) have been mounted into /db combine and import them
 if [ -n "$files" ]; then
     echo "Importing database..."
-    find /db -name '*.sql' | awk '{ print "source",$0 }' | MYSQL_PWD=$MYSQL_ROOT_PASSWORD mysql -u root $MYSQL_DATABASE --batch
+    find /db -name '*.sql' | awk '{ print "source",$0 }' | mysql --batch
     rm /db/*.sql
 else
     echo "No file to import found."


### PR DESCRIPTION
## The Problem:
The import script was not updated with the introduction of the .my.cnf to the database container. This prevents the import script from importing successfully.

## The Fix:
The credentials and database are removed from the mysql command, as they are defined by .my.cnf.

## The Test:
The v0.4.0 image tag has been updated with this fix. It should be tested as part of drud/ddev#285

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

