### PR TITLE
Use cp instead of mv for install of my.cnf, so it can be repeated

### DIFF
--- a/5.7/files/entrypoint.sh
+++ b/5.7/files/entrypoint.sh
@@ -115,7 +115,7 @@ if [ "$1" = 'mysqld' ]; then
 
 	# This .my.cnf configuration prevents the initialization process from
 	# succeeding, so it is moved into place after initialization is complete.
-	mv /root/mysqlclient.cnf /root/.my.cnf
+	cp /root/mysqlclient.cnf /root/.my.cnf
 fi
 
 


### PR DESCRIPTION
## The Problem:

`ddev restart` or a docker restart resulted in an endless loop of the mysql container restarting with the complaint:
```
mv: cannot stat '/root/mysqlclient.cnf': No such file or directory
```

## The Fix:

Use a cp command instead of 'mv' so that the command can be repeated on a later startup.

## The Test:

Use drud/mysql-docker-local-57:20170613_cp_not_mv with ddev and do a restart to see that the mysql container recovers gracefully. For extra credit do a docker restart.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

After acceptance:
- [ ] Create a new release, push to dockerhub
- [ ] Bump ddev mysql version